### PR TITLE
Update requirements.txt - cloudmesh-common required

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 jmespath
 oyaml
+cloudmesh-common


### PR DESCRIPTION
In order to get a python 3.12 program to run as per the example I needed to add the 'cloudmesh-common' package with pip. 

I don't know why it is required. (It is included in the requirements-dev.txt file.)